### PR TITLE
Update bipedal-locomotion-framework version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ on:
     - cron: '0 2 * * *'
     
 env:
-    #TODO change with first release after this commit
-    BipedalLocomotionFramework_TAG: master
+    BipedalLocomotionFramework_TAG: v0.12.0
     action-restore-cache: 'true'
 jobs:
     build:
@@ -91,9 +90,8 @@ jobs:
           run: |
             # bipedal-locomotion-framework
             cd ${GITHUB_WORKSPACE}
-            git clone --depth 1 https://github.com/ami-iit/bipedal-locomotion-framework blf
+            git clone --depth 1 --single-branch --branch ${BipedalLocomotionFramework_TAG} https://github.com/ami-iit/bipedal-locomotion-framework blf
             cd blf
-            git checkout ${BipedalLocomotionFramework_TAG}
             mkdir -p build
             cd build
             cmake -GNinja .. \

--- a/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
+++ b/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
@@ -7,7 +7,7 @@ include(BiomechanicalAnalysisFrameworkFindDependencies)
 ########################## Mandatory dependencies ###############################
 # Find all packages
 
-find_package(BipedalLocomotionFramework 0.11.200 REQUIRED) #TODO version
+find_package(BipedalLocomotionFramework 0.12.0 REQUIRED)
 
 ########################## Optional dependencies  ##############################
 


### PR DESCRIPTION
Update `bipedal-locomotion-framework` dependency to the [latest release](https://github.com/ami-iit/bipedal-locomotion-framework/releases/tag/v0.12.0)