### PR TITLE
Fix CI

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -12,4 +12,4 @@ dependencies:
   - spdlog
   - catch2>=3.3.0
   - manif
-  - bipedal-locomotion-framework
+  - bipedal-locomotion-framework>=0.18.0


### PR DESCRIPTION
I noticed that the CI is failing; comparing the conda list of a working CI, I noticed that the version of 'blf' installed is different, it ts the 0.16.0 in the working CI and 0.15.0 in the failing CI so I modified the `.yml` file to specify the required minimum version of 'blf`.