### PR TITLE
Fix installation of the examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
                   -DFRAMEWORK_COMPILE_YarpImplementation=ON \
                   -DBUILD_TESTING:BOOL=ON \
+                  -DBUILD_EXAMPLES:BOOL=ON \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
 
         - name: Configure [Windows]
@@ -95,6 +96,7 @@ jobs:
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
                   -DFRAMEWORK_COMPILE_YarpImplementation=ON \
                   -DBUILD_TESTING:BOOL=ON \
+                  -DBUILD_EXAMPLES:BOOL=ON \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
                     
         # Build step          

--- a/src/examples/IK/CMakeLists.txt
+++ b/src/examples/IK/CMakeLists.txt
@@ -10,8 +10,9 @@ find_package(matioCpp REQUIRED)
 if(NOT BipedalLocomotionFramework_FOUND)
   find_package(BipedalLocomotionFramework 0.16.0 REQUIRED)
 endif()
-find_package(BiomechanicalAnalysisFramework REQUIRED)
-find_package(YARP 3.4.0 REQUIRED)
+if(NOT FRAMEWORK_COMPILE_examples)
+    find_package(BiomechanicalAnalysisFramework REQUIRED)
+endif()
 
 add_executable(exampleIK)
 

--- a/src/examples/IK/CMakeLists.txt
+++ b/src/examples/IK/CMakeLists.txt
@@ -7,7 +7,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ConfigFolderPath.h.in" "${CMAKE_CURRENT_BINARY_DIR}/ConfigFolderPath.h" @ONLY)
 
 find_package(matioCpp REQUIRED)
-find_package(BipedalLocomotionFramework 0.12.0 REQUIRED)
+if(NOT BipedalLocomotionFramework_FOUND)
+  find_package(BipedalLocomotionFramework 0.16.0 REQUIRED)
+endif()
 find_package(BiomechanicalAnalysisFramework REQUIRED)
 find_package(YARP 3.4.0 REQUIRED)
 


### PR DESCRIPTION
While I was showing how to install this project to @Gianlucamilani, the following error occurs in the compilation if the flag `BUILD_EXAMPLES` is ON:
```
Call Stack (most recent call first):
   /home/dgorbani/mambaforge/envs/baf_test_3/lib/cmake/YARP/YARPConfig.cmake:183 (include)
   /home/dgorbani/mambaforge/envs/baf_test_3/lib/cmake/BipedalLocomotionFramework/BipedalLocomotionFrameworkConfig.cmake:27 (find_package)
   src/examples/IK/CMakeLists.txt:10 (find_package)
```

I added an if statement in the CMakeList of the examples that checks if `BipedalLocomotionFramework` is already found, and if it is found the `find_package` is skipped.