### PR TITLE
Add method to update all the tasks at once

### DIFF
--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -28,12 +28,6 @@ namespace BiomechanicalAnalysis
 namespace IK
 {
 
-struct nodeData
-{
-    manif::SO3d I_R_IMU;
-    manif::SO3Tangentd I_omega_IMU = manif::SO3d::Tangent::Zero();
-};
-
 // clang-format off
 /**
  * @brief HumanIK class is a class in which the inverse kinematics problem is solved.
@@ -385,8 +379,6 @@ public:
      * @return true if the joint regularization task is updated correctly
      */
     bool updateJointConstraintsTask();
-
-    bool updateOrientationGravityTasks(std::unordered_map<int, nodeData> nodeStruct);
 
     /**
      * set the calibration matrix between the IMU and the link

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -397,6 +397,13 @@ public:
     bool TPoseCalibrationNode(const int node, const manif::SO3d& I_R_IMU);
 
     /**
+     * set the calibration matrix between the IMU and the link for all the nodes
+     * @param nodeStruct unordered map containing the node number and the calibration matrix
+     * @return true if the calibration matrix is set correctly
+     */
+    bool TPoseCalibrationNodes(std::unordered_map<int, nodeData> nodeStruct);
+
+    /**
      * this function solves the inverse kinematics problem and integrate the joint velocity to
      * compute the joint positions and the base pose; it also updates the state of the
      * KinDynComputations object passed to the class

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -185,8 +185,7 @@ bool HumanIK::updateOrientationTask(const int node,
     // Check if the node number is valid
     if (m_OrientationTasks.find(node) == m_OrientationTasks.end())
     {
-        BiomechanicalAnalysis::log()->error("[HumanIK::setNodeSetPoint] Invalid node number {}.",
-                                            node);
+        BiomechanicalAnalysis::log()->error("[HumanIK::setNodeSetPoint] Invalid node number.");
         return false;
     }
 
@@ -207,8 +206,7 @@ bool HumanIK::updateGravityTask(const int node, const manif::SO3d& I_R_IMU)
     // check if the node number is valid
     if (m_GravityTasks.find(node) == m_GravityTasks.end())
     {
-        BiomechanicalAnalysis::log()->error("[HumanIK::setNodeSetPoint] Invalid node number {}.",
-                                            node);
+        BiomechanicalAnalysis::log()->error("[HumanIK::setNodeSetPoint] Invalid node number.");
         return false;
     }
 
@@ -270,41 +268,6 @@ bool HumanIK::updateJointConstraintsTask()
 {
     // Update the joint constraints task
     return m_jointConstraintsTask->update();
-}
-
-bool HumanIK::updateOrientationGravityTasks(std::unordered_map<int, nodeData> nodeStruct)
-{
-    // Update the orientation and gravity tasks
-    for (const auto& [node, data] : nodeStruct)
-    {
-        if (m_OrientationTasks.find(node) != m_OrientationTasks.end())
-        {
-            if (!updateOrientationTask(node, data.I_R_IMU, data.I_omega_IMU))
-            {
-                BiomechanicalAnalysis::log()->error("[HumanIK::updateOrientationGravityTasks] "
-                                                    "Error in updating the orientation task of "
-                                                    "node {}",
-                                                    node);
-                return false;
-            }
-        } else if (m_GravityTasks.find(node) != m_GravityTasks.end())
-        {
-            if (!updateGravityTask(node, data.I_R_IMU))
-            {
-                BiomechanicalAnalysis::log()->error("[HumanIK::updateOrientationGravityTasks] "
-                                                    "Error in updating the gravity task of node {}",
-                                                    node);
-                return false;
-            }
-        } else
-        {
-            BiomechanicalAnalysis::log()->error("[HumanIK::updateOrientationGravityTasks] "
-                                                "Invalid node number {}.",
-                                                node);
-            return false;
-        }
-    }
-    return true;
 }
 
 bool HumanIK::TPoseCalibrationNode(const int node, const manif::SO3d& I_R_IMU)

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -334,6 +334,22 @@ bool HumanIK::TPoseCalibrationNode(const int node, const manif::SO3d& I_R_IMU)
     return true;
 }
 
+bool HumanIK::TPoseCalibrationNodes(std::unordered_map<int, nodeData> nodeStruct)
+{
+    // Update the orientation and gravity tasks
+    for (const auto& [node, data] : nodeStruct)
+    {
+        if (!TPoseCalibrationNode(node, data.I_R_IMU))
+        {
+            BiomechanicalAnalysis::log()->error("[HumanIK::TPoseCalibrationNodes] Error in "
+                                                "calibrating the node {}",
+                                                node);
+            return false;
+        }
+    }
+    return true;
+}
+
 bool HumanIK::advance()
 {
     // Initialize ok flag to true

--- a/src/IK/tests/HumanIKTest.cpp
+++ b/src/IK/tests/HumanIKTest.cpp
@@ -43,13 +43,6 @@ TEST_CASE("InverseKinematic test")
     Eigen::Vector3d desiredDirection;
     desiredDirection << 1.0, 2.0, 3.0;
 
-    std::unordered_map<int, BiomechanicalAnalysis::IK::nodeData> mapNodeData;
-    mapNodeData[11].I_R_IMU.setIdentity();
-    mapNodeData[6].I_R_IMU = I_R_IMU;
-    mapNodeData[6].I_omega_IMU = I_omega_IMU;
-    mapNodeData[7].I_R_IMU = I_R_IMU;
-    mapNodeData[7].I_omega_IMU = I_omega_IMU;
-
     qInitial.setConstant(0.0);
 
     REQUIRE(ik.initialize(paramHandler, kinDyn));
@@ -57,7 +50,6 @@ TEST_CASE("InverseKinematic test")
     REQUIRE(ik.updateOrientationTask(3, I_R_IMU, I_omega_IMU));
     REQUIRE(ik.updateFloorContactTask(10, 11.0));
     REQUIRE(ik.updateGravityTask(10, I_R_IMU));
-    REQUIRE(ik.updateOrientationGravityTasks(mapNodeData));
     REQUIRE(ik.updateJointConstraintsTask());
     REQUIRE(ik.updateJointRegularizationTask());
     REQUIRE(ik.advance());

--- a/src/IK/tests/configTestIK.ini
+++ b/src/IK/tests/configTestIK.ini
@@ -94,14 +94,6 @@ kp                              1.0
 node_number                     10
 weight                          (1.0 1.0)
 
-[GRAVITY_TASK_1]
-type                            "GravityTask"
-robot_velocity_variable_name    "robot_velocity"
-target_frame_name               "link11"
-kp                              1.0
-node_number                     11
-weight                          (1.0 1.0)
-
 [FLOOR_CONTACT_TASK_1]
 type                            "FloorContactTask"
 robot_velocity_variable_name    "robot_velocity"


### PR DESCRIPTION
With this PR I add two new methods; the first one updates all the orientation and gravity task at once by passing an unordered map with the number of nodes and the new struct ['nodeStruct'](https://github.com/ami-iit/biomechanical-analysis-framework/blob/71e44c84cd9d6adc7fa8bfade907b59ddf3340b2/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h#L31-L35) containing the orientation and angular velocity data of the nodes. The second one calibrates all the nodes by passing the already described unordered map. 