### PR TITLE
Fix bug updateFloorContactTasks in HumanIK

### DIFF
--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -9,6 +9,13 @@ using namespace BipedalLocomotion::ContinuousDynamicalSystem;
 using namespace BipedalLocomotion::Conversions;
 using namespace std::chrono_literals;
 
+constexpr size_t WRENCH_FORCE_X = 0;
+constexpr size_t WRENCH_FORCE_Y = 1;
+constexpr size_t WRENCH_FORCE_Z = 2;
+constexpr size_t WRENCH_TORQUE_X = 3;
+constexpr size_t WRENCH_TORQUE_Y = 4;
+constexpr size_t WRENCH_TORQUE_Z = 5;
+
 bool HumanIK::initialize(std::weak_ptr<const BipedalLocomotion::ParametersHandler::IParametersHandler> handler,
                          std::shared_ptr<iDynTree::KinDynComputations> kinDyn)
 {
@@ -284,7 +291,7 @@ bool HumanIK::updateFloorContactTasks(const std::unordered_map<int, Eigen::Matri
 {
     for (const auto& [node, data] : wrenchMap)
     {
-        if (!updateFloorContactTask(node, data(2)))
+        if (!updateFloorContactTask(node, data(WRENCH_FORCE_Z)))
         {
             BiomechanicalAnalysis::log()->error("[HumanIK::updateFloorContactTasks] Error in updating "
                                                 "the floor contact task of node {}",

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -284,7 +284,7 @@ bool HumanIK::updateFloorContactTasks(const std::unordered_map<int, Eigen::Matri
 {
     for (const auto& [node, data] : wrenchMap)
     {
-        if (!updateFloorContactTask(node, data(5)))
+        if (!updateFloorContactTask(node, data(2)))
         {
             BiomechanicalAnalysis::log()->error("[HumanIK::updateFloorContactTasks] Error in updating "
                                                 "the floor contact task of node {}",


### PR DESCRIPTION
As per title, this PR fix a bug in the method `updateFloorContactTasks()` of the class `HumanIK`. Basically, I was checking the z component of the torque instead of the z component of the force to check if the foot was in contact with the floor.