### PR TITLE
Fix gravity task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           if: matrix.os == 'macOS-latest'
           shell: bash -l {0}
           run: |
-            export QT_HOST_PATH=$CONDA_PREFIX
+            echo "QT_HOST_PATH=${CONDA_PREFIX}" >> $GITHUB_ENV
         
         # Print the environment variables to simplify development and debugging
         - name: Environment Variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
           with:
             environment-file: ci_env.yml
             channel-priority: true
+
+        - name: Set QT_HOST_PATH_env var [macOS]
+          if: matrix.os == 'macOS-latest'
+          shell: bash -l {0}
+          run: |
+            export QT_HOST_PATH=$CONDA_PREFIX
         
         # Print the environment variables to simplify development and debugging
         - name: Environment Variables

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -199,7 +199,7 @@ bool HumanIK::updateGravityTask(const int node, const manif::SO3d& I_R_IMU)
     // W_R_link = W_R_WIMU * WIMU_R_IMU * IMU_R_link
     I_R_link = m_GravityTasks[node].calibrationMatrix * I_R_IMU * m_GravityTasks[node].IMU_R_link;
 
-    // set the set point of the gravity task choosing the z direction of the W_R_link rotation
+    // set the set point of the gravity task choosing the z direction of the link_R_W rotation
     // matrix
     return m_GravityTasks[node].task->setSetPoint((I_R_link.rotation().transpose().rightCols(1)));
 }

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -201,7 +201,7 @@ bool HumanIK::updateGravityTask(const int node, const manif::SO3d& I_R_IMU)
 
     // set the set point of the gravity task choosing the z direction of the W_R_link rotation
     // matrix
-    return m_GravityTasks[node].task->setSetPoint(I_R_link.rotation().rightCols(1));
+    return m_GravityTasks[node].task->setSetPoint((I_R_link.rotation().transpose().rightCols(1)));
 }
 
 bool HumanIK::updateFloorContactTask(const int node, const double verticalForce)

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -213,6 +213,19 @@ bool HumanIK::updateFloorContactTask(const int node, const double verticalForce)
         BiomechanicalAnalysis::log()->error("[HumanIK::updateFloorContactTask] Invalid node number.");
         return false;
     }
+    if (m_tPose == true)
+    {
+        m_FloorContactTasks[node].footInContact = false;
+        Eigen::VectorXd jointPositions;
+        jointPositions.resize(this->getDoFsNumber());
+        jointPositions.setZero();
+        Eigen::Matrix4d basePose;
+        basePose.setIdentity();
+        Eigen::VectorXd baseVelocity;
+        baseVelocity.resize(6);
+        baseVelocity.setZero();
+        m_kinDyn->setRobotState(basePose, jointPositions, baseVelocity, m_jointVelocities, m_gravity);
+    }
 
     // if the vertical force is greater than the threshold and if the foot is not yet in contact,
     // set the weight of the associated task to the weight of the task and set the set point of the


### PR DESCRIPTION
With this PR I fixed the bug in the gravity task; basically, the gravity task implemented in `blf` requires the direction vector to be in body-frame while the one that was set was in world-frame. Moreover, I fixed the `t-pose` calibration of the feet; now, when the `t-pose` is performed, the setpoint of the floor contact task is recomputed starting from the `t-pose` position.