### PR TITLE
Align the T Pose to HDE

### DIFF
--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -138,6 +138,7 @@ private:
                                                                  // will be calibrated using Tpose
                                                                  // script
         Eigen::Vector3d weight;
+        std::string frameName;
     };
 
     /**
@@ -152,6 +153,7 @@ private:
         Eigen::Vector2d weight;
         int nodeNumber;
         std::string taskName;
+        std::string frameName;
     };
 
     /**
@@ -429,6 +431,10 @@ public:
      * @return true if the calibration matrix is set correctly
      */
     bool TPoseCalibrationNodes(std::unordered_map<int, nodeData> nodeStruct);
+
+    bool calibrateWorldYaw(std::unordered_map<int, nodeData> nodeStruct);
+
+    bool calibrateAllWithWorld(std::unordered_map<int, nodeData> nodeStruct, std::string frameRef = "");
 
     /**
      * this function solves the inverse kinematics problem and integrate the joint velocity to

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -137,8 +137,8 @@ private:
                                                                  // to the World of the IMU, which
                                                                  // will be calibrated using Tpose
                                                                  // script
-        Eigen::Vector3d weight;
-        std::string frameName;
+        Eigen::Vector3d weight; // Weight of the task
+        std::string frameName; // Name of the frame in which the task is expressed
     };
 
     /**

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -29,6 +29,9 @@ namespace BiomechanicalAnalysis
 namespace IK
 {
 
+/**
+ * @brief Struct containing the orientation and the angular velocity of an IMU
+ */
 struct nodeData
 {
     manif::SO3d I_R_IMU;
@@ -405,7 +408,9 @@ public:
 
     /**
      * update the orientation for all the nodes of the SO3 and gravity tasks
-     * @param nodeStruct unordered map containing the node number and the calibration matrix
+     * @param nodeStruct unordered map containing the struct node data (see
+     * https://github.com/ami-iit/biomechanical-analysis-framework/blob/338129086dca24989552a20ecc1c9dec0492806a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h#L32)
+     * containing the orientation and the angular velocity of an IMU, associated to the node number
      * @return true if the calibration matrix is set correctly
      */
     bool updateOrientationAndGravityTasks(const std::unordered_map<int, nodeData>& nodeStruct);
@@ -419,14 +424,19 @@ public:
 
     /**
      * remove the offset on the yaw of the IMUs world
-     * @param nodeStruct unordered map containing the node number and the IMUs measurements
+     * @param nodeStruct unordered map containing the struct node data (see
+     * https://github.com/ami-iit/biomechanical-analysis-framework/blob/338129086dca24989552a20ecc1c9dec0492806a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h#L32)
+     * containing the orientation and the angular velocity of an IMU, associated to the node number
      * @return true if the calibration matrix is set correctly
+     * @note gravity is expected to be aligned with the z-axis of the IMU frame
      */
     bool calibrateWorldYaw(std::unordered_map<int, nodeData> nodeStruct);
 
     /**
      * compute the calibration matrix between the IMU frame and the associated link frame
-     * @param nodeStruct unordered map containing the node number and the IMUs measurements
+     * @param nodeStruct unordered map containing the struct node data (see
+     * https://github.com/ami-iit/biomechanical-analysis-framework/blob/338129086dca24989552a20ecc1c9dec0492806a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h#L32)
+     * containing the orientation and the angular velocity of an IMU, associated to the node number
      * @param frameRef reference frame used as world
      * @return true if the calibration matrix is set correctly
      */

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -418,22 +418,18 @@ public:
     bool updateFloorContactTasks(const std::unordered_map<int, Eigen::Matrix<double, 6, 1>>& wrenchMap);
 
     /**
-     * set the calibration matrix between the IMU and the link
-     * @param node node number
-     * @param I_R_IMU calibration matrix
+     * remove the offset on the yaw of the IMUs world
+     * @param nodeStruct unordered map containing the node number and the IMUs measurements
      * @return true if the calibration matrix is set correctly
      */
-    bool TPoseCalibrationNode(const int node, const manif::SO3d& I_R_IMU);
-
-    /**
-     * set the calibration matrix between the IMU and the link for all the nodes
-     * @param nodeStruct unordered map containing the node number and the calibration matrix
-     * @return true if the calibration matrix is set correctly
-     */
-    bool TPoseCalibrationNodes(std::unordered_map<int, nodeData> nodeStruct);
-
     bool calibrateWorldYaw(std::unordered_map<int, nodeData> nodeStruct);
 
+    /**
+     * compute the calibration matrix between the IMU frame and the associated link frame
+     * @param nodeStruct unordered map containing the node number and the IMUs measurements
+     * @param frameRef reference frame used as world
+     * @return true if the calibration matrix is set correctly
+     */
     bool calibrateAllWithWorld(std::unordered_map<int, nodeData> nodeStruct, std::string frameRef = "");
 
     /**

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -322,46 +322,6 @@ bool HumanIK::updateFloorContactTasks(const std::unordered_map<int, Eigen::Matri
     return true;
 }
 
-bool HumanIK::TPoseCalibrationNode(const int node, const manif::SO3d& I_R_IMU)
-{
-    m_tPose = true;
-    // check if the node number is valid
-    if ((m_OrientationTasks.find(node) == m_OrientationTasks.end()) && (m_GravityTasks.find(node) == m_GravityTasks.end()))
-    {
-        BiomechanicalAnalysis::log()->error("[HumanIK::TPoseCalibrationNode] Invalid node number.");
-        return false;
-    }
-
-    // compute the rotation matrix from the world to the world of the IMU as:
-    // W_R_WIMU = R_calib * (WIMU_R_IMU * IMU_R_link)^{T}
-    // where R_calib is assumed to be the identity
-    // The if condition checks whether the task is m_OrientationTasks or m_GravityTasks
-    if (m_OrientationTasks.find(node) != m_OrientationTasks.end())
-    {
-        m_OrientationTasks[node].calibrationMatrix = calib_W_R_link * (I_R_IMU * m_OrientationTasks[node].IMU_R_link).inverse();
-    } else
-    {
-        m_GravityTasks[node].calibrationMatrix = calib_W_R_link * (I_R_IMU * m_GravityTasks[node].IMU_R_link).inverse();
-    }
-    return true;
-}
-
-bool HumanIK::TPoseCalibrationNodes(std::unordered_map<int, nodeData> nodeStruct)
-{
-    // Update the orientation and gravity tasks
-    for (const auto& [node, data] : nodeStruct)
-    {
-        if (!TPoseCalibrationNode(node, data.I_R_IMU))
-        {
-            BiomechanicalAnalysis::log()->error("[HumanIK::TPoseCalibrationNodes] Error in "
-                                                "calibrating the node {}",
-                                                node);
-            return false;
-        }
-    }
-    return true;
-}
-
 bool HumanIK::calibrateWorldYaw(std::unordered_map<int, nodeData> nodeStruct)
 {
     // reset the robot state

--- a/src/IK/tests/HumanIKTest.cpp
+++ b/src/IK/tests/HumanIKTest.cpp
@@ -57,6 +57,8 @@ TEST_CASE("InverseKinematics test")
     REQUIRE(ik.updateOrientationAndGravityTasks(mapNodeData));
     REQUIRE(ik.updateJointConstraintsTask());
     REQUIRE(ik.updateJointRegularizationTask());
+    REQUIRE(ik.calibrateWorldYaw(mapNodeData));
+    REQUIRE(ik.calibrateAllWithWorld(mapNodeData, "link1"));
     REQUIRE(ik.advance());
     REQUIRE(ik.getJointPositions(JointPositions));
     REQUIRE(ik.getJointVelocities(JointVelocities));


### PR DESCRIPTION
This PR adds two methods to align the T Pose computation to the one implemented in HDE; those two methods allow to reset the offset on the yaw of the IMUs and compute the `IMU_R_link` rotation matrix.