### PR TITLE
Fix location of bindings library in the build directory

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(pybind11_baf PRIVATE
 # # The generated Python dynamic module must have the same name as the pybind11
 # # module, i.e. `bindings`.
 set_target_properties(pybind11_baf PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${baf_PYTHON_PACKAGE}"
+    LIBRARY_OUTPUT_DIRECTORY "${BAF_PYTHON_PACKAGE}"
     OUTPUT_NAME "bindings")
 
 if(FRAMEWORK_TEST_PYTHON_BINDINGS)


### PR DESCRIPTION
Without this fix, calling in Python `import biomechanical_analysis_framework` in the build directory results in an error, even if `baf` is installed as a system level (and so the import works fine in any other directory:

~~~
Python 3.12.6 | packaged by conda-forge | (main, Sep 30 2024, 18:08:52) [GCC 13.3.0] on linuxType "help", "copyright", "credits" or "license" for more information.
>>> import biomechanical_analysis_framework as bafTraceback (most recent call last):  
File "<stdin>", line 1, in <module>  File "/home/evelyd/biomechanical-analysis-framework_conda/build/biomechanical_analysis_framework/__init__.py", line 1, in <module>    from .bindings import 
*ModuleNotFoundError: No module named 'biomechanical_analysis_framework.bindings' 
~~~

The reason for this is that inside the build directory a file `build/biomechanical_analysis_framework/__init__.py` is placed, so that a user could do `import biomechanical_analysis_framework` even if the bindings are not installed. However, to make sure that this works, also the bindings binaries need to be placed in `build/biomechanical_analysis_framework/`, but this was not happening due to a type on the CMake variable `baf_PYTHON_PACKAGE`, fixed by this PR.