### PR TITLE
CI: Remove outdated CDT package to provide libgl dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,11 @@ jobs:
           if: matrix.os == 'ubuntu-latest'
           shell: bash -l {0}
           run: |
-            # Additional dependencies only useful on Linux
-            # See https://github.com/robotology/robotology-superbuild/issues/477
-            micromamba install expat-cos6-x86_64 libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesalib mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
-
+            # Additional dependencies only useful on Linux, both at the conda and the system level,
+            # see https://conda-forge.org/docs/maintainer/maintainer_faq/#how-do-i-fix-the-libglso1-import-error
+            micromamba install libgl-devel
+            sudo apt-get update
+            sudo apt install libgl1-mesa-dri libglx-mesa0 libegl-mesa0
 
         # ===================
         # CMAKE-BASED PROJECT


### PR DESCRIPTION
Since the `libgl` library was packaged in conda-forge, we can now just depend on it (and the related system-level OpenGL drivers, installed via apt) instead of rely on CDTs packages, see https://conda-forge.org/docs/maintainer/maintainer_faq/#how-do-i-fix-the-libglso1-import-error for upstream conda-forge documentation, see https://github.com/robotology/gz-sim-yarp-plugins/pull/250 for a similar documentation.

Fix https://github.com/ami-iit/biomechanical-analysis-framework/issues/58 .