### PR TITLE
Fix find_package(BiomechanicalAnalysisFramework)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,5 +139,5 @@ jobs:
           run: |
             cd build
             cmake --install . --config ${{matrix.build_type}} --verbose
-            # Re-enable when we understand why cmake-package-check is not found
-            # cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging
+            :: Re-enable when we understand why cmake-package-check is not found
+            :: cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,14 +85,13 @@ jobs:
             mkdir -p build
             cd build
             cmake -G"Ninja" .. \
-                  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
                   -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
                   -DFRAMEWORK_COMPILE_YarpImplementation=ON \
                   -DBUILD_TESTING:BOOL=ON \
                   -DBUILD_EXAMPLES:BOOL=ON \
                   -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON \
-                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
+                  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 
         - name: Configure [Windows]
           if: matrix.os == 'windows-latest'
@@ -108,7 +107,7 @@ jobs:
                   -DBUILD_TESTING:BOOL=ON \
                   -DBUILD_EXAMPLES:BOOL=ON \
                   -DFRAMEWORK_COMPILE_PYTHON_BINDINGS:BOOL=ON \
-                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
+                  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX/Library
                     
         # Build step          
         - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
 
 
         - name: Install [Windows]
+          if: matrix.os == 'windows-latest'
           shell: cmd /C CALL {0}
           run: |
             cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,4 +130,4 @@ jobs:
           run: |
             cd build
             cmake --install . --config ${{matrix.build_type}} --verbose
-          - cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging
+            cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,17 @@ jobs:
             export PATH=$PATH:${GITHUB_WORKSPACE}/build/install/bin:${GITHUB_WORKSPACE}/install/deps/bin
             ctest --output-on-failure -C ${{ matrix.build_type }} .
 
-        - name: Install
+        - name: Install  [Ubuntu, macOS]
+          if: matrix.os != 'windows-latest'
           shell: bash -l {0}
+          run: |
+            cd build
+            cmake --install . --config ${{matrix.build_type}} --verbose
+            cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging
+
+
+        - name: Install [Windows]
+          shell: cmd /C CALL {0}
           run: |
             cd build
             cmake --install . --config ${{matrix.build_type}} --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,4 +139,5 @@ jobs:
           run: |
             cd build
             cmake --install . --config ${{matrix.build_type}} --verbose
-            cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging
+            # Re-enable when we understand why cmake-package-check is not found
+            # cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
             mkdir -p build
             cd build
             cmake -G"Ninja" .. \
+                  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
                   -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
                   -DFRAMEWORK_COMPILE_YarpImplementation=ON \
@@ -100,6 +101,7 @@ jobs:
             mkdir -p build
             cd build
             cmake -G"Visual Studio 17 2022" .. \
+                  -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX/Library \
                   -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
                   -DFRAMEWORK_COMPILE_YarpImplementation=ON \
@@ -122,3 +124,10 @@ jobs:
             cd build
             export PATH=$PATH:${GITHUB_WORKSPACE}/build/install/bin:${GITHUB_WORKSPACE}/install/deps/bin
             ctest --output-on-failure -C ${{ matrix.build_type }} .
+
+        - name: Install
+          shell: bash -l {0}
+          run: |
+            cd build
+            cmake --install . --config ${{matrix.build_type}} --verbose
+          - cmake-package-check BiomechanicalAnalysisFramework --targets BiomechanicalAnalysis::IK BiomechanicalAnalysis::ID BiomechanicalAnalysis::CommonConversions BiomechanicalAnalysis::Logging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ include(AddBiomechanicalAnalysisPythonModule)
 
 
 include(InstallBasicPackageFiles)
-get_property(FRAMEWORK_PRIVATE_DEPENDENCIES GLOBAL PROPERTY BiomechanicalAnalysisFramework_PrivateDependencies)
-get_property(FRAMEWORK_PUBLIC_DEPENDENCIES GLOBAL PROPERTY BiomechanicalAnalysisFramework_PublicDependencies)
 install_basic_package_files(${PROJECT_NAME}
                             NAMESPACE BiomechanicalAnalysis::
                             VERSION ${BiomechanicalAnalysisFramework_VERSION}
@@ -95,8 +93,7 @@ install_basic_package_files(${PROJECT_NAME}
                             TARGETS_PROPERTY BiomechanicalAnalysisFramework_TARGETS
                             VARS_PREFIX ${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES ${FRAMEWORK_PUBLIC_DEPENDENCIES}
-                            PRIVATE_DEPENDENCIES ${FRAMEWORK_PRIVATE_DEPENDENCIES})
+                            DEPENDENCIES Eigen3 iDynTree BipedalLocomotionFramework)
 
 
 include(AddUninstallTarget)

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -14,3 +14,4 @@ dependencies:
   - manif
   - bipedal-locomotion-framework>=0.19.0
   - pybind11
+  - cmake-package-check

--- a/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
+++ b/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
@@ -17,6 +17,8 @@ endif()
 ########################## Mandatory dependencies ###############################
 # Find all packages
 
+find_package(Eigen3 REQUIRED)
+find_package(iDynTree REQUIRED)
 find_package(BipedalLocomotionFramework 0.12.0 REQUIRED)
 
 ########################## Optional dependencies  ##############################

--- a/src/Logging/YarpImplementation/CMakeLists.txt
+++ b/src/Logging/YarpImplementation/CMakeLists.txt
@@ -5,7 +5,7 @@ if(FRAMEWORK_COMPILE_YarpImplementation)
     NAME                   TextLoggingYarpImplementation
     SOURCES                src/YarpLogger.cpp
     PUBLIC_HEADERS         include/BiomechanicalAnalysis/Logging/YarpLogger.h
-    PUBLIC_LINK_LIBRARIES  BiomechanicalAnalysis::Logging 
+    PRIVATE_LINK_LIBRARIES BiomechanicalAnalysis::Logging 
                            BipedalLocomotion::TextLoggingYarpImplementation
                            YARP::YARP_os
     INSTALLATION_FOLDER    Logging)


### PR DESCRIPTION
Fix https://github.com/ami-iit/biomechanical-analysis-framework/issues/64 .

In particular:
* Pass to install_basic_package_files's `DEPENDENCIES` argument the name of all the packages that contain targets that are passed as `PUBLIC_LINK_LIBRARIES`, so that the generated `BiomechanicalAnalysisFrameworkConfig.cmake` can `find_dependency` them
* Explicitly `find_package` for `Eigen3` and `iDynTree`, as they are package that we directly use in this library
* Change all the linked libraries in `TextLoggingYarpImplementation` to `PRIVATE_LINK_LIBRARIES`, as the `BiomechanicalAnalysis/Logging/YarpLogger.h` header does not include any external header.
* Add step in CI to check if `find_package(BiomechanicalAnalysisFramework)` works with https://github.com/ami-iit/cmake-package-check