### PR TITLE
Fix compilation against future bipedal-locomotion-framework 0.21.0 (blf master as of March 2025)

### DIFF
--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -10,7 +10,18 @@
 #include <iDynTree/KinDynComputations.h>
 
 // BipedalLocomotion
+#if __has_include(<BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemVelocityKinematics.h>)
+#include <BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemVelocityKinematics.h>
+#else
 #include <BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemKinematics.h>
+namespace BipedalLocomotion
+{
+namespace ContinuousDynamicalSystem
+{
+typedef FloatingBaseSystemVelocityKinematics FloatingBaseSystemKinematics;
+}
+}
+#endif
 #include <BipedalLocomotion/ContinuousDynamicalSystem/ForwardEuler.h>
 #include <BipedalLocomotion/IK/GravityTask.h>
 #include <BipedalLocomotion/IK/JointLimitsTask.h>
@@ -108,9 +119,9 @@ private:
     struct System
     {
         std::shared_ptr<BipedalLocomotion::ContinuousDynamicalSystem::ForwardEuler<
-            BipedalLocomotion::ContinuousDynamicalSystem::FloatingBaseSystemKinematics>>
+            BipedalLocomotion::ContinuousDynamicalSystem::FloatingBaseSystemVelocityKinematics>>
             integrator;
-        std::shared_ptr<BipedalLocomotion::ContinuousDynamicalSystem::FloatingBaseSystemKinematics> dynamics;
+        std::shared_ptr<BipedalLocomotion::ContinuousDynamicalSystem::FloatingBaseSystemVelocityKinematics> dynamics;
     };
 
     System m_system; /** Struct containing the integrator and the dynamics */

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -18,7 +18,7 @@ namespace BipedalLocomotion
 {
 namespace ContinuousDynamicalSystem
 {
-typedef FloatingBaseSystemVelocityKinematics FloatingBaseSystemKinematics;
+typedef FloatingBaseSystemKinematics FloatingBaseSystemVelocityKinematics;
 }
 }
 #endif

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -47,10 +47,10 @@ bool HumanIK::initialize(std::weak_ptr<const BipedalLocomotion::ParametersHandle
         return false;
     }
 
-    m_system.dynamics = std::make_shared<FloatingBaseSystemKinematics>();
+    m_system.dynamics = std::make_shared<FloatingBaseSystemVelocityKinematics>();
     m_system.dynamics->setState({m_basePose.topRightCorner<3, 1>(), toManifRot(m_basePose.topLeftCorner<3, 3>()), m_jointPositions});
 
-    m_system.integrator = std::make_shared<ForwardEuler<FloatingBaseSystemKinematics>>();
+    m_system.integrator = std::make_shared<ForwardEuler<FloatingBaseSystemVelocityKinematics>>();
     m_system.integrator->setDynamicalSystem(m_system.dynamics);
 
     // Variable for number of DoF of the model


### PR DESCRIPTION
Fix compilation against current BLF master (future BLF 0.21) after the breaking change in https://github.com/ami-iit/bipedal-locomotion-framework/pull/950 .

To detect between blf version before and after https://github.com/ami-iit/bipedal-locomotion-framework/pull/950, I used the `__has_include(<BipedalLocomotion/ContinuousDynamicalSystem/FloatingBaseSystemVelocityKinematics.h>)` check. This is not perfect as it may fail if one downgrades his/her BLF installation in the superbuild without deleting the install folder or if multiple version of blf are installed, but I think it is the right compromise between the correctness and the maintenance effort.