### PR TITLE
baf_kpi: Remove argparse dependency

### DIFF
--- a/baf_kpi/pyproject.toml
+++ b/baf_kpi/pyproject.toml
@@ -3,7 +3,7 @@ name = "baf-kpi"
 version = "0.2.0"   # The version of this python package should be aligned with the version number in  "https://github.com/ami-iit/biomechanical-analysis-framework/blob/main/CMakeLists.txt#L10"
 description = "Python project to compute KPI parameters"
 license.file = "LICENSE"
-dependencies = ["numpy", "matplotlib", "pandas", "scipy", "h5py", "idyntree", "rich", "joblib", "argparse", "meshcat", "resolve-robotics-uri-py"]
+dependencies = ["numpy", "matplotlib", "pandas", "scipy", "h5py", "idyntree", "rich", "joblib", "meshcat", "resolve-robotics-uri-py"]
 
 
 [build-system]


### PR DESCRIPTION
The `argparse` module is part of the Python standard library since Python 3.2 (see https://docs.python.org/3/library/argparse.html), and the `argparse` package on PyPI is an old package that was meant to permit to use argparse for Python version earlier then 3.2, so I think it is perfectly fine to remove the `argparse` dependency, also to avoid confusion in users.