### PR TITLE
Change name variable config for floor contact task

### DIFF
--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -186,7 +186,7 @@ private:
     {
         std::shared_ptr<BipedalLocomotion::IK::R3Task> task;
         Eigen::Vector3d weight;
-        int nodeNumber;
+        int taskNumber;
         bool footInContact{false};
         Eigen::Vector3d setPointPosition;
         std::string taskName;
@@ -283,7 +283,7 @@ public:
      * |:-----------:|:------------------------------:|:----------:|:--------------------------------------------------------------------------------------------:|:---------:|
      * |`FloorContactTask`|           `type`               |  `string`  |                       Type of the task. The value to be set is `FloorContactTask`       |  Yes  |
      * |`FloorContactTask`| `robot_velocity_variable_name` |  `string`  |Name of the variable contained in `VariablesHandler` describing the generalized robot velocity|  Yes  |
-     * |`FloorContactTask`|         `node_number`          |   `int`    |                  Node number of the task. The node number must be unique.               |  Yes  |
+     * |`FloorContactTask`|         `floor_contact_task`   |   `int`    |                  Node number of the task. The node number must be unique.               |  Yes  |
      * |`FloorContactTask`|          `kp_linear`           |  `double`  |                          Gain of the distance controller                                |  Yes  |
      * |`FloorContactTask`|         `frame_name`           |  `string`  |                 Name of the frame to which apply the floor contact task                 |  Yes  |
      * |`FloorContactTask`|   `vertical_force_threshold`   |  `double`  |                 Threshold of the vertical force to consider the foot in contact         |  Yes  |

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -796,12 +796,12 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
     constexpr auto logPrefix = "[HumanIK::initializeFloorContactTask]";
 
     // Variable to store the node number
-    int nodeNumber;
+    int taskNumber;
     // Flag to indicate successful initialization
     bool ok{true};
 
     // Retrieve node number parameter from the task handler
-    if (!taskHandler->getParameter("node_number", nodeNumber))
+    if (!taskHandler->getParameter("floor_contact_task", taskNumber))
     {
         BiomechanicalAnalysis::log()->error("{} Parameter node_number of the {} task is missing", logPrefix, taskName);
         return false;
@@ -809,7 +809,7 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
 
     // Retrieve frame name parameter from the task handler and assign it to the corresponding
     // FloorContactTask
-    if (!taskHandler->getParameter("frame_name", m_FloorContactTasks[nodeNumber].frameName))
+    if (!taskHandler->getParameter("frame_name", m_FloorContactTasks[taskNumber].frameName))
     {
         BiomechanicalAnalysis::log()->error("{} Parameter frame_name of the {} task is missing", logPrefix, taskName);
         return false;
@@ -836,7 +836,7 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
 
     // Retrieve vertical force threshold parameter from the task handler and assign it to the
     // corresponding FloorContactTask
-    if (!taskHandler->getParameter("vertical_force_threshold", m_FloorContactTasks[nodeNumber].verticalForceThreshold))
+    if (!taskHandler->getParameter("vertical_force_threshold", m_FloorContactTasks[taskNumber].verticalForceThreshold))
     {
         BiomechanicalAnalysis::log()->error("{} Parameter vertical_force_threshold of the {} task "
                                             "is missing",
@@ -846,21 +846,21 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
     }
 
     // Map weight vector to Eigen::Vector3d and assign it to the corresponding FloorContactTask
-    m_FloorContactTasks[nodeNumber].weight = Eigen::Map<Eigen::Vector3d>(weight.data());
+    m_FloorContactTasks[taskNumber].weight = Eigen::Map<Eigen::Vector3d>(weight.data());
 
     // Set node number and task name for the FloorContactTask
-    m_FloorContactTasks[nodeNumber].nodeNumber = nodeNumber;
-    m_FloorContactTasks[nodeNumber].taskName = taskName;
+    m_FloorContactTasks[taskNumber].taskNumber = taskNumber;
+    m_FloorContactTasks[taskNumber].taskName = taskName;
 
     // Create an R3Task object for the floor contact task
-    m_FloorContactTasks[nodeNumber].task = std::make_shared<BipedalLocomotion::IK::R3Task>();
+    m_FloorContactTasks[taskNumber].task = std::make_shared<BipedalLocomotion::IK::R3Task>();
 
     // Initialize the R3Task object
-    ok = ok && m_FloorContactTasks[nodeNumber].task->setKinDyn(m_kinDyn);
-    ok = ok && m_FloorContactTasks[nodeNumber].task->initialize(taskHandler);
+    ok = ok && m_FloorContactTasks[taskNumber].task->setKinDyn(m_kinDyn);
+    ok = ok && m_FloorContactTasks[taskNumber].task->initialize(taskHandler);
 
     // Add the floor contact task to the QP solver
-    ok = ok && m_qpIK.addTask(m_FloorContactTasks[nodeNumber].task, taskName, 1, m_FloorContactTasks[nodeNumber].weight);
+    ok = ok && m_qpIK.addTask(m_FloorContactTasks[taskNumber].task, taskName, 1, m_FloorContactTasks[taskNumber].weight);
 
     // Check if initialization was successful
     return ok;

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -803,7 +803,7 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
     // Retrieve node number parameter from the task handler
     if (!taskHandler->getParameter("floor_contact_task", taskNumber))
     {
-        BiomechanicalAnalysis::log()->error("{} Parameter node_number of the {} task is missing", logPrefix, taskName);
+        BiomechanicalAnalysis::log()->error("{} Parameter floor_contact_task of the {} task is missing", logPrefix, taskName);
         return false;
     }
 

--- a/src/IK/tests/configTestIK.toml
+++ b/src/IK/tests/configTestIK.toml
@@ -102,7 +102,7 @@ type = "FloorContactTask"
 robot_velocity_variable_name = "robot_velocity"
 frame_name = "link10"
 kp_linear = 1.0
-node_number = 10
+floor_contact_task = 10
 weight = [10.0, 10.0, 10.0]
 vertical_force_threshold = 60.0
 

--- a/src/examples/IK/exampleIK.ini
+++ b/src/examples/IK/exampleIK.ini
@@ -136,7 +136,7 @@ type                            "FloorContactTask"
 robot_velocity_variable_name    "robot_velocity"
 frame_name                      "RightToe"
 kp_linear                       60.0
-node_number                     2
+floor_contact_task              21
 weight                          (1.0 1.0 1.0)
 vertical_force_threshold        60.0
 
@@ -145,7 +145,7 @@ type                            "FloorContactTask"
 robot_velocity_variable_name    "robot_velocity"
 frame_name                      "LeftToe"
 kp_linear                       60.0
-node_number                     1
+floor_contact_task              11
 weight                          (1.0 1.0 1.0)
 vertical_force_threshold        60.0
 


### PR DESCRIPTION
This PR addresses an issue regarding the `node_number` attribute in the floor contact task.  

As pointed out by @Gianlucamilani, the current naming of the `node_number` variable might be misleading. 

The `node_number` values follow a structured logic based on side (left/right) and front/back positioning:  

- The **first digit** represents the **side**:  
  - `1` → Left  
  - `2` → Right  
- The **second digit** represents the **sensor position**:  
  - `1` → Front (corresponding to the **toe frame**)  
  - `2` → Back (corresponding to the **heel frame**)  

These numbers are **not** related to the node indices of the lower leg links, which might cause confusion.  

To improve clarity, I propose renaming the `node_number` variable in `floor_contact_task` to better reflect its purpose and avoid misinterpretation.  
