### PR TITLE
Enable log-of ikSolution-vs-IMUtarget-link-orientation for all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The capability to provide "ik-solution-link-orientation" and "target-imu-orientation" as quantities (https://github.com/ami-iit/component_human-biomechanics/issues/47)
 - The HumanIK class (https://github.com/ami-iit/biomechanical-analysis-framework/pull/15)
 - The `CHANGELOG.md` file
 - The `Logging` feature (https://github.com/ami-iit/biomechanical-analysis-framework/pull/10)
+

--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -141,6 +141,7 @@ private:
                                                                  // to the World of the IMU, which
                                                                  // will be calibrated using Tpose
                                                                  // script
+        manif::SO3d W_R_link; // Calibrated orientation of the link in the inertial frame
         Eigen::Vector3d weight; // Weight of the task
         std::string frameName; // Name of the frame in which the task is expressed
     };
@@ -156,6 +157,7 @@ private:
         manif::SO3d IMU_R_link_init; // Initial value of the rotation matrix from the IMU to related link, set through config
                                      // file
         manif::SO3d calibrationMatrix = manif::SO3d::Identity();
+        manif::SO3d W_R_link; // Calibrated orientation of the link in the inertial frame
         Eigen::Vector2d weight;
         int nodeNumber;
         std::string taskName;
@@ -500,7 +502,22 @@ public:
      * @return true if the base angular velocity is retrieved correctly
      */
     bool getBaseAngularVelocity(Eigen::Ref<Eigen::Vector3d> baseAngularVelocity) const;
-};
+
+    /**
+     * get the calibration matrix between the world and the link
+     * @param node node number
+     * @return calibration matrix
+     */
+    const manif::SO3d& getCalibratedIMURotation(int node) const;
+
+    /**
+     * get the frame name of the orientation task
+     * @param node node number
+     * @return frame name
+     */
+    std::string getNodeFrameName(int node) const;
+
+};          
 
 } // namespace IK
 } // namespace BiomechanicalAnalysis


### PR DESCRIPTION
As described in this issue https://github.com/ami-iit/component_human-biomechanics/issues/47, this PR enables the capability in the iFeelBAF applications to retrieve some addirtional quantities for debugging purposes:

- "ik-solution-link-orientation" and
- "target-imu-orientation"
The comparison of these two quantities expressed as rpy angles may provide useful insights to understand discrepancies between real movements and the ones performed by the avatar in the digital application

