### PR TITLE
Initialize FloorContactTask with setpoint

### DIFF
--- a/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
+++ b/src/IK/include/BiomechanicalAnalysis/IK/InverseKinematics.h
@@ -188,7 +188,7 @@ private:
         Eigen::Vector3d weight;
         int nodeNumber;
         bool footInContact{false};
-        Eigen::Vector3d setPointPosition;
+        Eigen::Vector3d setPointPosition = Eigen::Vector3d::Zero();
         std::string taskName;
         std::string frameName;
         double verticalForceThreshold;

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -858,6 +858,7 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
     // Initialize the R3Task object
     ok = ok && m_FloorContactTasks[nodeNumber].task->setKinDyn(m_kinDyn);
     ok = ok && m_FloorContactTasks[nodeNumber].task->initialize(taskHandler);
+    ok = ok && m_FloorContactTasks[nodeNumber].task->setSetPoint(Eigen::Vector3d::Zero());
 
     // Add the floor contact task to the QP solver
     ok = ok && m_qpIK.addTask(m_FloorContactTasks[nodeNumber].task, taskName, 1, m_FloorContactTasks[nodeNumber].weight);

--- a/src/IK/src/InverseKinematics.cpp
+++ b/src/IK/src/InverseKinematics.cpp
@@ -274,11 +274,8 @@ bool HumanIK::updateFloorContactTask(const int node, const double verticalForce,
         m_FloorContactTasks[node].footInContact = false;
     }
 
-    // if the foot is in contact, set the set point of the task
-    if (m_FloorContactTasks[node].footInContact)
-    {
-        ok = m_FloorContactTasks[node].task->setSetPoint(m_FloorContactTasks[node].setPointPosition);
-    }
+    // Set the set point of the task
+    ok = m_FloorContactTasks[node].task->setSetPoint(m_FloorContactTasks[node].setPointPosition);
 
     return ok;
 }
@@ -858,7 +855,6 @@ bool HumanIK::initializeFloorContactTask(const std::string& taskName,
     // Initialize the R3Task object
     ok = ok && m_FloorContactTasks[nodeNumber].task->setKinDyn(m_kinDyn);
     ok = ok && m_FloorContactTasks[nodeNumber].task->initialize(taskHandler);
-    ok = ok && m_FloorContactTasks[nodeNumber].task->setSetPoint(Eigen::Vector3d::Zero());
 
     // Add the floor contact task to the QP solver
     ok = ok && m_qpIK.addTask(m_FloorContactTasks[nodeNumber].task, taskName, 1, m_FloorContactTasks[nodeNumber].weight);


### PR DESCRIPTION
Thanks to @dariosortino we solved an issue related to the IK solver: 
```

[2025-03-28 08:51:24.762] [thread: 10579] [blf] [error] [R3Task::update] The set-point has not been set at least once.
[2025-03-28 08:51:24.762] [thread: 10579] [blf] [error] [QPInverseKinematics::advance] Unable to update the task named RIGHT_HEEL_TASK.
[2025-03-28 08:51:24.762] [thread: 10579] [blf] [error] [HumanIK::advance] Error in the QP solver.
[2025-03-28 08:51:24.762] [thread: 10579] [blf] [error] Cannot advance the inverse kinematics solver
```

this error appears launching the `iFeelBAFSubscriber` application. Thanks to the support of @GiulioRomualdi , we understood this error appears if the task is not provided with a setpoint

Initializing the setpoint to zero, the error disappears
