### PR TITLE
Fix use of deprecated iDynTree header

### DIFF
--- a/src/ID/include/BiomechanicalAnalysis/ID/InverseDynamics.h
+++ b/src/ID/include/BiomechanicalAnalysis/ID/InverseDynamics.h
@@ -11,7 +11,7 @@
 // iDynTree headers
 #include <iDynTree/BerdyHelper.h>
 #include <iDynTree/BerdySparseMAPSolver.h>
-#include <iDynTree/Core/SparseMatrix.h>
+#include <iDynTree/SparseMatrix.h>
 #include <iDynTree/KinDynComputations.h>
 
 // BipedalLocomotion headers


### PR DESCRIPTION
There was a warning in public header, that is particularly annoying as it propagates to any downstream project using BAF:

~~~
[ 90%] Building CXX object iFeelBAF/CMakeFiles/iFeelBAFReplay.dir/iFeelBAFReplay.cpp.o
In file included from /home/runner/micromamba/envs/ifeelenv/include/BiomechanicalAnalysis/ID/InverseDynamics.h:14,
                 from /home/runner/work/component_ifeel/component_ifeel/element_wearable_sw/iFeelBAF/iFeelBAFReplay.cpp:21:
/home/runner/micromamba/envs/ifeelenv/include/iDynTree/Core/SparseMatrix.h:8:4: warning: #warning <iDynTree/Core/SparseMatrix.h> is deprecated. Please use <iDynTree/SparseMatrix.h>. To disable this warning use -Wno-deprecated. [-Wcpp]
    8 |   #warning <iDynTree/Core/SparseMatrix.h> is deprecated. Please use <iDynTree/SparseMatrix.h>. To disable this warning use -Wno-deprecated.
      |    ^~~~~~~
[ 91%] Linking CXX executable ../bin/iFeelBAFReplay
[ 91%] Built target iFeelBAFReplay
[ 92%] Building CXX object iFeelBAF/CMakeFiles/iFeelBAFSubscriber.dir/iFeelBAFSubscriber.cpp.o
In file included from /home/runner/micromamba/envs/ifeelenv/include/BiomechanicalAnalysis/ID/InverseDynamics.h:14,
                 from /home/runner/work/component_ifeel/component_ifeel/element_wearable_sw/iFeelBAF/iFeelBAFSubscriber.cpp:18:
/home/runner/micromamba/envs/ifeelenv/include/iDynTree/Core/SparseMatrix.h:8:4: warning: #warning <iDynTree/Core/SparseMatrix.h> is deprecated. Please use <iDynTree/SparseMatrix.h>. To disable this warning use -Wno-deprecated. [-Wcpp]
    8 |   #warning <iDynTree/Core/SparseMatrix.h> is deprecated. Please use <iDynTree/SparseMatrix.h>. To disable this warning use -Wno-deprecated.
      |    ^~~~~~~
~~~

This PR fixes it by using the non-deprecated header (as mentioned in the warning message). The new header is available since iDynTree 10.0.0 that was released ~1 year and half ago (https://github.com/robotology/idyntree/releases/tag/v10.0.0), so I think we should be good to go.
