### PR TITLE
Do not  get ResolveRoboticsURICpp with FetchContent

### DIFF
--- a/ci_env.yml
+++ b/ci_env.yml
@@ -15,3 +15,5 @@ dependencies:
   - bipedal-locomotion-framework>=0.19.0
   - pybind11
   - cmake-package-check
+  - libresolve-robotics-uri-cpp
+

--- a/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
+++ b/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
@@ -21,7 +21,22 @@ endif()
 find_package(Eigen3 REQUIRED)
 find_package(iDynTree REQUIRED)
 find_package(BipedalLocomotionFramework 0.19.0 REQUIRED)
-find_package(ResolveRoboticsURICpp REQUIRED)
+
+# Dependencies supported either directly of via FetchContent
+if(NOT DEFINED FRAMEWORK_USE_SYSTEM_ResolveRoboticsURICpp)
+  find_package(ResolveRoboticsURICpp QUIET)
+endif()
+option(FRAMEWORK_USE_SYSTEM_ResolveRoboticsURICpp "Use find_package to find ResolveRoboticsURICpp " ${ResolveRoboticsURICpp_FOUND})
+if(FRAMEWORK_USE_SYSTEM_ResolveRoboticsURICpp)
+  find_package(ResolveRoboticsURICpp REQUIRED)
+else()
+  FetchContent_Declare(
+    ResolveRoboticsURICpp
+    GIT_REPOSITORY https://github.com/ami-iit/resolve-robotics-uri-cpp
+    GIT_TAG        v0.0.3
+  )
+  FetchContent_MakeAvailable(ResolveRoboticsURICpp)
+endif()
 
 ########################## Optional dependencies  ##############################
 

--- a/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
+++ b/cmake/BiomechanicalAnalysisFrameworkDependencies.cmake
@@ -21,6 +21,7 @@ endif()
 find_package(Eigen3 REQUIRED)
 find_package(iDynTree REQUIRED)
 find_package(BipedalLocomotionFramework 0.19.0 REQUIRED)
+find_package(ResolveRoboticsURICpp REQUIRED)
 
 ########################## Optional dependencies  ##############################
 

--- a/src/ID/CMakeLists.txt
+++ b/src/ID/CMakeLists.txt
@@ -1,12 +1,3 @@
-include(FetchContent)
-
-FetchContent_Declare(
-  ResolveRoboticsURICpp
-  GIT_REPOSITORY https://github.com/ami-iit/resolve-robotics-uri-cpp
-  GIT_TAG        v0.0.2
-)
-FetchContent_MakeAvailable(ResolveRoboticsURICpp)
-
 add_biomechanical_analysis_library(
     NAME                   ID
     PUBLIC_HEADERS         include/BiomechanicalAnalysis/ID/InverseDynamics.h


### PR DESCRIPTION
In some environments, `FetchContent` is prone to network flake and errors.

For this reason, this PR switches the dependency on `ResolveRoboticsURICpp` CMake package (provided by https://github.com/gbionics/resolve-robotics-uri-cpp, on conda-forge by https://github.com/conda-forge/resolve-robotics-uri-cpp-feedstock) from FetchContent to `find_package` .

