### PR TITLE
Add fixed base param

### DIFF
--- a/devices/BAFStateProvider/BAFStateProvider.cpp
+++ b/devices/BAFStateProvider/BAFStateProvider.cpp
@@ -126,6 +126,7 @@ public:
 
     // ── Configuration ─────────────────────────────────────────────────────────
     std::string baseName{"Pelvis"};
+    bool forceFixedBase{false};
     std::vector<std::string> jointNames;
 
     std::vector<SensorTarget> sensorTargets;
@@ -354,6 +355,9 @@ bool baf::devices::BAFStateProvider::open(yarp::os::Searchable& config)
 
     // ── Floating base frame ───────────────────────────────────────────────────
     pImpl->baseName = config.check("floatingBaseFrame", yarp::os::Value("Pelvis")).asString();
+    yInfo() << LogPrefix << "Using base name:" << pImpl->baseName;
+    pImpl->forceFixedBase = config.check("forceFixedBase", yarp::os::Value(false)).asBool();
+    yInfo() << LogPrefix << "Forcing fixed base ? " << (pImpl->forceFixedBase ? "yes" : "no");
 
     // ── URDF ──────────────────────────────────────────────────────────────────
     if (!config.check("urdf"))
@@ -1017,6 +1021,12 @@ void baf::devices::BAFStateProvider::run()
 
             pImpl->solution.jointPositions[tgt.jointIndex] = position;
             pImpl->solution.jointVelocities[tgt.jointIndex] = velocity;
+        }
+
+        if (pImpl->forceFixedBase)
+        {
+            pImpl->solution.baseOrientation = {1, 0, 0, 0}; // Temporary fix: override base orientation to identity
+            pImpl->solution.baseVelocity = {0, 0, 0, 0, 0, 0}; // Temporary fix: override base velocity to zero
         }
     }
 }

--- a/devices/BAFStateProvider/BAFStateProvider.cpp
+++ b/devices/BAFStateProvider/BAFStateProvider.cpp
@@ -1025,8 +1025,9 @@ void baf::devices::BAFStateProvider::run()
 
         if (pImpl->forceFixedBase)
         {
-            pImpl->solution.baseOrientation = {1, 0, 0, 0}; // Temporary fix: override base orientation to identity
-            pImpl->solution.baseVelocity = {0, 0, 0, 0, 0, 0}; // Temporary fix: override base velocity to zero
+            pImpl->solution.baseOrientation = {1, 0, 0, 0};
+            pImpl->solution.baseVelocity = {0, 0, 0, 0, 0, 0};
+            pImpl->solution.basePosition = {0, 0, 0};
         }
     }
 }

--- a/devices/BAFStateProvider/BAFStateProvider.h
+++ b/devices/BAFStateProvider/BAFStateProvider.h
@@ -33,6 +33,7 @@ class BAFStateProvider;
  *   period          [s]     Control loop period (default 0.017)
  *   urdf            [str]   URDF filename (resolved via YARP ResourceFinder)
  *   floatingBaseFrame [str] Floating base link name (default "Pelvis")
+ *   forceFixedBase  [bool]  If true, force output base orientation to identity and base velocity to zero (default false)
  *
  * BAF IK configuration is embedded directly in the device config. See the
  * BAF IK documentation for the expected task groups and solver parameters.

--- a/devices/BAFStateProvider/README.md
+++ b/devices/BAFStateProvider/README.md
@@ -9,6 +9,7 @@
 | `period` | float [s] | Control loop period (default `0.017`) |
 | `urdf` | string | URDF filename (resolved via YARP ResourceFinder) |
 | `floatingBaseFrame` | string | Floating base link name (default `"Pelvis"`) |
+| `forceFixedBase` | bool | If `true`, force output base orientation to identity quaternion and base velocity to zero (default `false`) |
 | `rpcPortPrefix` | string | Prefix used for the RPC port and other device ports |
 | `tasks` | list | IK tasks to enable, each defined by a corresponding `<group>`/section in the config |
 

--- a/devices/conf/xml/BAFStateProvider_example.xml
+++ b/devices/conf/xml/BAFStateProvider_example.xml
@@ -57,6 +57,7 @@
         <param name="period">0.01</param>
         <param name="urdf">model.urdf</param>
         <param name="floatingBaseFrame">root_link</param>
+        <param name="forceFixedBase">false</param>
         <param name="rpcPortPrefix">stateProvider</param>
 
         <!-- BAF IK configuration: list the available tasks and map each one to a wearable sensor source. -->


### PR DESCRIPTION
This  PR introduces a parameter in BAFStateProvider which fixes the orientation of the base to the identity and velocity to zero. Solution of the IK is simply overriden a posteriori with such values.
Parameter is false by default so to keep the previous behaviour.